### PR TITLE
Fix content duplication in print mode

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -7,8 +7,8 @@
 }
 
 .c-links__item {
-  position: fixed;
-  top: -3em;
+  position: absolute;
+  top: -200em;
   padding: 0.5em;
   text-decoration: none;
   background-color: #000;


### PR DESCRIPTION
so the issue was in print mode the skip links appear on every page.


**Why did this happen?**
Fixed-position elements should repeat/shows on each page we print so that this happened.

**How to fix this?**
there are 3 options to fix this issue:
1. to keep the `position: fixed` and add bigger value to `top || left` to keep the element far away from being snapped in printing.
2. to change the `position: fixed` to `position: absolute` and add any negative value to `top | left` to hide the element from appearing on the screen.
3. hide the element in print mode 
```css

@media print {
  .c-links {
    display: none;
  }
}
```

** What I Implement **
I did the mix from 1 and 2.


in the screenshot, you can see the content of the links shows on the page this content related by the second page but it appears at the end of the first page so why this happened? that's happened cuz as I said before the fixed position repeats elements in every page + I was adding `top: -3em` so the element appears on the first page.

<img width="680" alt="Screen Shot 2020-04-28 at 6 14 11 PM" src="https://user-images.githubusercontent.com/13405108/80511381-526c4a00-897c-11ea-929f-6bdad0b361ef.png">
