### PR TITLE
Fix moving focus in IE11

### DIFF
--- a/demo/src/index.js
+++ b/demo/src/index.js
@@ -17,7 +17,7 @@ const Demo = () => {
       <main id="main" style={{ height: '100vh' }} tabIndex="-1">
         <a href="#hi">Hi Again</a>
       </main>
-      <footer id="footer" style={{ height: '50vh' }}>
+      <footer id="footer" style={{ height: '50vh' }} tabIndex="-1">
         <a href="#bye">Bye</a>
       </footer>
     </Fragment>


### PR DESCRIPTION
after a click on the skip button, the viewport may visually move the target of the skip link into view, that doesn't mean keyboard focus has moved. so to make sure the keyboard focus has moved we need to add `tabindex=-1` to the element.